### PR TITLE
Release version 0.4.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrggsave
 Type: Package
 Title: Save and Arrange Annotated Plots
-Version: 0.4.4.9000
+Version: 0.4.5
 Authors@R: c(
        person("Kyle T", "Baron", "", "kyleb@metrumrg.com", c("aut", "cre")),
        person("Metrum Research Group", role =  c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# mrggsave (development version)
+# mrggsave 0.4.5
 
 - New option `mrggsave.res` to set default resolution for devices 
   like `png()` and `jpeg()` (#42).


### PR DESCRIPTION
# mrggsave 0.4.5

- New option `mrggsave.res` to set default resolution for devices 
  like `png()` and `jpeg()` (#42).