### PR TITLE
ci: update ubuntu-20.04 jobs to ubuntu-22.04

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,31 +20,31 @@ jobs:
         #  * pbkrtest 0.5.2 requires R 4.1.
         #  * Matrix v1.7-0 requires R 4.4.
         config:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 3.6.3
             pbkrtest_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2023-12-05/src/contrib/pbkrtest_0.5.1.tar.gz'
             matrix_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2024-09-23/src/contrib/Matrix_1.6-5.tar.gz'
             # The latest versions of several dependencies require
             # newer R versions.
-            rspm: 'https://packagemanager.posit.co/cran/__linux__/focal/2023-11-15'
-          - os: ubuntu-20.04
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2023-11-15'
+          - os: ubuntu-22.04
             r: 4.0.5
             pbkrtest_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2023-12-05/src/contrib/pbkrtest_0.5.1.tar.gz'
             matrix_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2024-09-23/src/contrib/Matrix_1.6-5.tar.gz'
             # The latest versions of several dependencies require
             # newer R versions.
-            rspm: 'https://packagemanager.posit.co/cran/__linux__/focal/2024-07-22'
-          - os: ubuntu-20.04
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2024-07-22'
+          - os: ubuntu-22.04
             r: 4.1.3
             pbkrtest_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2023-12-05/src/contrib/pbkrtest_0.5.1.tar.gz'
             matrix_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2024-09-23/src/contrib/Matrix_1.6-5.tar.gz'
             # The latest versions of several dependencies require
             # newer R versions.
-            rspm: 'https://packagemanager.posit.co/cran/__linux__/focal/2024-07-22'
-          - os: ubuntu-20.04
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2024-07-22'
+          - os: ubuntu-22.04
             r: 4.2.3
             matrix_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2024-09-23/src/contrib/Matrix_1.6-5.tar.gz'
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 4.3.1
             matrix_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2024-09-23/src/contrib/Matrix_1.6-5.tar.gz'
           - os: ubuntu-latest


### PR DESCRIPTION
The ubuntu-20.04 image is deprecated as of 2025-02-01 and is scheduled to be retired on 2025-04-01.

https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions