### PR TITLE
Fix NULL labeller on list of plots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,4 +27,4 @@ Imports:
   rprojroot,
   withr
 Suggests: GGally, gtable, testthat, lattice, survminer, patchwork, survival
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/R/mrggsave.R
+++ b/R/mrggsave.R
@@ -435,13 +435,6 @@ mrggsave_common <- function(x,
     parent = .GlobalEnv
   )
 
-  label <- labeller(d)
-
-  if(length(label) != n) {
-    nn <- length(label)
-    stop("'label' must be length ",n ," (not ",nn,")", call.=FALSE)
-  }
-
   position <- match.arg(d$position, c("default", "left", "right"))
   if(position != "default") {
     if(position=="left") {

--- a/mrggsave.Rproj
+++ b/mrggsave.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: f3127b99-8e58-42b8-9d8d-a50696985543
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/tests/testthat/test-mrggsave-list.R
+++ b/tests/testthat/test-mrggsave-list.R
@@ -18,3 +18,17 @@ test_that("save a list [MRGS-TEST-028]", {
   expect_identical(basename(x),"testlist.pdf")
 })
 
+test_that("save a list of plots with no labels gh-48", {
+
+  out <- mrggsave(
+    list(p,p),
+    script = Script,
+    stem = "testlist-nolabel",
+    onefile = FALSE,
+    labeller = NULL
+  )
+  out <- basename(out)
+  expect_length(out,2)
+  expect_equal(out[[1]], "testlist-nolabel001.pdf")
+  expect_equal(out[[2]], "testlist-nolabel002.pdf")
+})

--- a/tests/testthat/test-mrggsave-list.R
+++ b/tests/testthat/test-mrggsave-list.R
@@ -32,3 +32,19 @@ test_that("save a list of plots with no labels gh-48", {
   expect_equal(out[[1]], "testlist-nolabel001.pdf")
   expect_equal(out[[2]], "testlist-nolabel002.pdf")
 })
+
+test_that("error for improper label function return", {
+
+  f <- function(d) return("a")
+
+  expect_error(
+    mrggsave(
+      list(p,p,p),
+      script = Script,
+      stem = "testlist-badlabel",
+      onefile = FALSE,
+      labeller = f
+    ),
+    "`label` must be length 3"
+  )
+})


### PR DESCRIPTION
See #48 - we couldn't save a list of plots with no annotation (`labeller` set to `NULL`). 

Investigation showed there was a test call of `labeller`, which I think ended up calling `ggplot2::labeller`. The point of the test call was to make sure labeller returned the right length (one label for each plot). This isn't needed because there is other code in `annotate_graphic()` to do this.  So the test call was removed.

A test is included to demonstrate that we still error with message when the label function isn't returning one label for each plot in the list. 