### PR TITLE
Release 0.4.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrggsave
 Type: Package
 Title: Save and Arrange Annotated Plots
-Version: 0.4.5.9000
+Version: 0.4.6
 Authors@R: c(
        person("Kyle T", "Baron", "", "kyleb@metrumrg.com", c("aut", "cre")),
        person("Metrum Research Group", role =  c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 - Fixed a bug where an error was encountered when trying to save a list 
   of plots with no annotation (`labeller = NULL`) (#49).
 
+- Updates for compatibility with glue 1.8.0 (#44).
+
 # mrggsave 0.4.5
 
 - New option `mrggsave.res` to set default resolution for devices 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
-# mrggsave (development version)
+# mrggsave 0.4.6
+
+## Bugs Fixed
+
+- Fixed a bug where an error was encountered when trying to save a list 
+  of plots with no annotation (`labeller = NULL`) (#49).
 
 # mrggsave 0.4.5
 


### PR DESCRIPTION
# mrggsave 0.4.6

## Bugs Fixed

- Fixed a bug where an error was encountered when trying to save a list 
  of plots with no annotation (`labeller = NULL`) (#49).

- Updates for compatibility with glue 1.8.0 (#44).