### PR TITLE
Move withr to Suggests to silence R CMD check note

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,5 +26,12 @@ Imports:
   fs, 
   rprojroot,
   withr
-Suggests: GGally, gtable, testthat, lattice, survminer, patchwork, survival
+Suggests:
+  GGally,
+  gtable,
+  lattice,
+  patchwork,
+  survival,
+  survminer,
+  testthat
 RoxygenNote: 7.3.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,8 +24,7 @@ Imports:
   rlang (>= 0.3.4), 
   glue, 
   fs, 
-  rprojroot,
-  withr
+  rprojroot
 Suggests:
   GGally,
   gtable,
@@ -33,5 +32,6 @@ Suggests:
   patchwork,
   survival,
   survminer,
-  testthat
+  testthat,
+  withr
 RoxygenNote: 7.3.2


### PR DESCRIPTION
Avoid the following note under R 4.2 and later:

    * checking dependencies in R code ... NOTE
    Namespace in Imports field not imported from: ‘withr’
     All declared Imports should be used.
