### PR TITLE
Use only basename when forming stem from script and tag

### DIFF
--- a/R/mrggsave.R
+++ b/R/mrggsave.R
@@ -387,7 +387,7 @@ mrggsave_common <- function(x,
   }
 
   if(!is.null(tag)) {
-    context <- getOption("mrggsave.use.context", script)
+    context <- getOption("mrggsave.use.context", basename(script))
     stem <- make_stem(context, tag)
   } else {
     stem <- paste0(stem, collapse = .sep())

--- a/tests/testthat/test-filename.R
+++ b/tests/testthat/test-filename.R
@@ -49,6 +49,15 @@ test_that("vector tag gets collapsed [MRGS-TEST-016]", {
   expect_equal(basename(ans), "test-filename-a-101-b.pdf")
 })
 
+test_that("use tag with full script path", {
+  ans <- mrggsave(
+    p,
+    script = "foo/bar/test-filename.R",
+    tag = "use-tag-full-path"
+  )
+  expect_equal(basename(ans), "test-filename-use-tag-full-path.pdf")
+})
+
 test_that("plots get named by object [MRGS-TEST-017]", {
   p1 <- p2 <- p3 <- p
   l <- named_plots(p1,p2,p3, tag = "bbb")


### PR DESCRIPTION
See example in #52 

There's a feature where you can set a context and save a series of plots using a combination of the context name and a "tag" that is supplied with each plot. 

```r
> mrggsave:::make_stem("foo.R", tag = "plot1")
[1] "foo-plot1"
```

The default "context" is the name of the script, but you can override that through an option. 

This was causing a problem when we started passing in the full path to the script: 


```r
> mrggsave:::make_stem("script/foo.R", tag = "plot1")
[1] "script/foo-plot1"
```

This PR just takes the `basename()` of `script` prior to starting this whole process off to ensure we don't get a path to output file that we didn't intend. 

The change here is only meant to preserve existing behavior, which was expecting `script` to be just the name of the script. 