### PR TITLE
Release 0.4.7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrggsave
 Type: Package
 Title: Save and Arrange Annotated Plots
-Version: 0.4.6
+Version: 0.4.7
 Authors@R: c(
        person("Kyle T", "Baron", "", "kyleb@metrumrg.com", c("aut", "cre")),
        person("Metrum Research Group", role =  c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# mrggsave 0.4.7
+
+## Bugs Fixed
+
+- Fixed bug when using a `tag` to name plots when a full path to `script` was
+  provided (#53).
+
 # mrggsave 0.4.6
 
 ## Bugs Fixed


### PR DESCRIPTION
# mrggsave 0.4.7

## Bugs Fixed

- Fixed bug when using a `tag` to name plots when a full path to `script` was
  provided (#53).
